### PR TITLE
Refactored ModuleProps Constructor Overloading

### DIFF
--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -24,39 +24,8 @@ class PaceMaker;
 
 class ModuleProps
 {
-public:	
-	ModuleProps()
-	{
-		fps = 60;
-		qlen = 20;
-		logHealth = false;		
-		logHealthFrequency = 1000;
-		quePushStrategyType = QuePushStrategy::BLOCKING;
-		maxConcurrentFrames = 0;
-		fIndexStrategyType = FIndexStrategy::FIndexStrategyType::AUTO_INCREMENT;
-	}
-
-	ModuleProps(int _fps)
-	{
-		fps = _fps;
-		qlen = 20;
-		logHealth = false;
-		logHealthFrequency = 1000;
-		quePushStrategyType = QuePushStrategy::BLOCKING;
-		maxConcurrentFrames = 0;
-		fIndexStrategyType = FIndexStrategy::FIndexStrategyType::AUTO_INCREMENT;
-	}
-
-	ModuleProps(int _fps, size_t _qlen, bool _logHealth)
-	{
-		fps = _fps;
-		qlen = _qlen;
-		logHealth = _logHealth;
-		logHealthFrequency = 1000;
-		quePushStrategyType = QuePushStrategy::BLOCKING;
-		maxConcurrentFrames = 0;
-		fIndexStrategyType = FIndexStrategy::FIndexStrategyType::AUTO_INCREMENT;
-	}
+public:
+	ModuleProps(int fps = 60,size_t qlen = 20,bool logHealth = false,int logHealthFrequency = 1000,QuePushStrategy::QuePushStrategyType quePushStrategyType = QuePushStrategy::BLOCKING,size_t maxConcurrentFrames = 0,FIndexStrategy::FIndexStrategyType fIndexStrategyType = FIndexStrategy::FIndexStrategyType::AUTO_INCREMENT){}
 
 	size_t getQLen()
 	{
@@ -69,15 +38,15 @@ public:
 		return 1024 + sizeof(fps) + sizeof(qlen) + sizeof(logHealth) + sizeof(logHealthFrequency) + sizeof(maxConcurrentFrames) + sizeof(skipN) + sizeof(skipD) + sizeof(quePushStrategyType) + sizeof(fIndexStrategyType);
 	}
 
-	int fps; // can be updated during runtime with setProps
-	size_t qlen; // run time changing doesn't effect this
-	bool logHealth; // can be updated during runtime with setProps
+	int fps;				// can be updated during runtime with setProps
+	size_t qlen;			// run time changing doesn't effect this
+	bool logHealth;			// can be updated during runtime with setProps
 	int logHealthFrequency; // 1000 by default - logs the health stats frequency
 
 	// used for VimbaSource where we want to create the max frames and keep recycling it
-	// for the VimbaDrive we announce frames after init - 100/200 
+	// for the VimbaDrive we announce frames after init - 100/200
 	// see VimbaSource.cpp on how it is used
-	size_t maxConcurrentFrames; 
+	size_t maxConcurrentFrames;
 
 	// 0/1 - skipN == 0 -  don't skip any - process all
 	// 1/1 - skipN == skipD - skip all - don't process any
@@ -86,31 +55,35 @@ public:
 	// 2/3 skips 2 out of every 3 frames
 	// 5/6 skips 5 out of every 6 frames
 	// skipD >= skipN
-	int skipN = 0; 
-	int skipD = 1; 
+	int skipN = 0;
+	int skipD = 1;
 
 	QuePushStrategy::QuePushStrategyType quePushStrategyType;
 	FIndexStrategy::FIndexStrategyType fIndexStrategyType;
-		
+
 private:
-	friend class Module;	
+	friend class Module;
 
 	friend class boost::serialization::access;
-	template<class Archive>
-	void serialize(Archive & ar, const unsigned int /* file_version */) {
-		ar & fps & qlen & logHealth & logHealthFrequency & maxConcurrentFrames & skipN & skipD & quePushStrategyType & fIndexStrategyType;
+	template <class Archive>
+	void serialize(Archive &ar, const unsigned int /* file_version */)
+	{
+		ar &fps &qlen &logHealth &logHealthFrequency &maxConcurrentFrames &skipN &skipD &quePushStrategyType &fIndexStrategyType;
 	}
 };
 
-class Module {
-	
+class Module
+{
+
 public:
-	enum Kind {
+	enum Kind
+	{
 		SOURCE,
 		TRANSFORM,
 		SINK
 	};
-	enum ModuleState {
+	enum ModuleState
+	{
 		Initialized,
 		Running,
 		EndOfStreamNormal,
@@ -123,21 +96,21 @@ public:
 	string getId() { return myId; }
 	double getPipelineFps();
 	uint64_t getTickCounter();
-		
-	string addOutputPin(framemetadata_sp& metadata); // throw exception
+
+	string addOutputPin(framemetadata_sp &metadata); // throw exception
 	vector<string> getAllOutputPinsByType(int type);
-	void addOutputPin(framemetadata_sp& metadata, string& pinId);
-	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open = true); 
-	bool setNext(boost::shared_ptr<Module> next, bool open = true); // take all the output pins			
-	bool addFeedback(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open = true); 
-	bool addFeedback(boost::shared_ptr<Module> next, bool open = true); // take all the output pins			
+	void addOutputPin(framemetadata_sp &metadata, string &pinId);
+	bool setNext(boost::shared_ptr<Module> next, vector<string> &pinIdArr, bool open = true);
+	bool setNext(boost::shared_ptr<Module> next, bool open = true); // take all the output pins
+	bool addFeedback(boost::shared_ptr<Module> next, vector<string> &pinIdArr, bool open = true);
+	bool addFeedback(boost::shared_ptr<Module> next, bool open = true); // take all the output pins
 	boost_deque<boost::shared_ptr<Module>> getConnectedModules();
 
 	bool relay(boost::shared_ptr<Module> next, bool open);
-		
+
 	virtual bool init();
 	void operator()(); //to support boost::thread
-	virtual bool run();	
+	virtual bool run();
 	bool play(bool play);
 	bool queueStep();
 	virtual bool step();
@@ -146,26 +119,27 @@ public:
 	virtual bool isFull();
 
 	void adaptQueue(boost::shared_ptr<FrameContainerQueueAdapter> queAdapter);
-	
-	void register_consumer(boost::function<void(Module*, unsigned short)>, bool bFatal=false);
-	boost::shared_ptr<PaceMaker> getPacer() { return pacer; }	
-	static frame_sp getFrameByType(frame_container& frames, int frameType);	
+
+	void register_consumer(boost::function<void(Module *, unsigned short)>, bool bFatal = false);
+	boost::shared_ptr<PaceMaker> getPacer() { return pacer; }
+	static frame_sp getFrameByType(frame_container &frames, int frameType);
+
 protected:
-	virtual boost_deque<frame_sp> getFrames(frame_container& frames);	
-	virtual bool process(frame_container& frames) { return false; }
-	virtual bool processEOS(string& pinId) { return true; } // EOS is propagated in stepNonSource for every encountered EOSFrame - pinId is first stream in the map
-	virtual bool processSOS(frame_sp& frame) { return true; } // SOS is Start of Stream	
+	virtual boost_deque<frame_sp> getFrames(frame_container &frames);
+	virtual bool process(frame_container &frames) { return false; }
+	virtual bool processEOS(string &pinId) { return true; }	  // EOS is propagated in stepNonSource for every encountered EOSFrame - pinId is first stream in the map
+	virtual bool processSOS(frame_sp &frame) { return true; } // SOS is Start of Stream
 	virtual bool shouldTriggerSOS();
 	virtual bool produce() { return false; }
-	bool stepNonSource(frame_container& frames);
-	bool preProcessNonSource(frame_container& frames);
+	bool stepNonSource(frame_container &frames);
+	bool preProcessNonSource(frame_container &frames);
 	bool isRunning() { return mRunning; }
 
 	ModuleProps getProps();
-	void setProps(ModuleProps& props);
-	void fillProps(ModuleProps& props);
-	template<class T>
-	void addPropsToQueue(T& props)
+	void setProps(ModuleProps &props);
+	void fillProps(ModuleProps &props);
+	template <class T>
+	void addPropsToQueue(T &props)
 	{
 		auto size = props.getSerializeSize();
 		auto frame = makeCommandFrame(size, mPropsChangeMetadata);
@@ -177,22 +151,22 @@ protected:
 		frames.insert(make_pair("props_change", frame));
 		Module::push(frames);
 	}
-	virtual bool handlePropsChange(frame_sp& frame);
-	virtual bool handleCommand(Command::CommandType type, frame_sp& frame);
-	template<class T>
-	bool handlePropsChange(frame_sp& frame, T& props)
+	virtual bool handlePropsChange(frame_sp &frame);
+	virtual bool handleCommand(Command::CommandType type, frame_sp &frame);
+	template <class T>
+	bool handlePropsChange(frame_sp &frame, T &props)
 	{
 		//deserialize
 		deSerialize<T>(props, frame);
 
-		// set props		
+		// set props
 		Module::setProps(props);
 
 		return true;
 	}
 
-	template<class T>
-	bool queueCommand(T& cmd)
+	template <class T>
+	bool queueCommand(T &cmd)
 	{
 		auto size = cmd.getSerializeSize();
 		auto frame = makeCommandFrame(size, mCommandMetadata);
@@ -207,74 +181,75 @@ protected:
 		return true;
 	}
 
-	template<class T>
-	void getCommand(T& cmd, frame_sp& frame)
+	template <class T>
+	void getCommand(T &cmd, frame_sp &frame)
 	{
 		Utils::deSerialize(cmd, frame->data(), frame->size());
 	}
-	
-	frame_sp makeCommandFrame(size_t size, framemetadata_sp& metadata);
-	frame_sp makeFrame(size_t size, string& pinId);
+
+	frame_sp makeCommandFrame(size_t size, framemetadata_sp &metadata);
+	frame_sp makeFrame(size_t size, string &pinId);
 	frame_sp makeFrame(size_t size); // use only if 1 output pin is there
 	frame_sp makeFrame();
-	frame_sp makeFrame(frame_sp& bigFrame, size_t& newSize, string& pinId);
+	frame_sp makeFrame(frame_sp &bigFrame, size_t &newSize, string &pinId);
 	frame_sp getEOSFrame();
 	frame_sp getEmptyFrame();
 
-	void setMetadata(std::string& pinId, framemetadata_sp& metadata);
-		
-	virtual bool send(frame_container& frames, bool forceBlockingPush=false);
-	virtual void sendEOS();	
+	void setMetadata(std::string &pinId, framemetadata_sp &metadata);
+
+	virtual bool send(frame_container &frames, bool forceBlockingPush = false);
+	virtual void sendEOS();
 	virtual void sendEoPFrame();
-	
-	boost::function<void () > onStepFail;
+
+	boost::function<void()> onStepFail;
 	//various behaviours for stepFail:
 	void ignore(int times); //do nothing
 	void stop_onStepfail();
 	void emit_event(unsigned short eventID); //regular events
 	void emit_fatal(unsigned short eventID); //fatal events need a permanent handler
-		
-	friend class PipeLine;	
 
-	boost::function<void(Module*, unsigned short)> event_consumer;
-	boost::function<void(Module*, unsigned short)> fatal_event_consumer;
-		
+	friend class PipeLine;
+
+	boost::function<void(Module *, unsigned short)> event_consumer;
+	boost::function<void(Module *, unsigned short)> fatal_event_consumer;
+
 	enum ModuleState module_state;
 	void setModuleState(enum ModuleState es) { module_state = es; }
-	ModuleState getModuleState() {
+	ModuleState getModuleState()
+	{
 		return module_state;
 	}
 
-	virtual bool validateInputPins();  // invoked with setInputPin
-	virtual bool validateOutputPins(); // invoked with addOutputPin
+	virtual bool validateInputPins();															   // invoked with setInputPin
+	virtual bool validateOutputPins();															   // invoked with addOutputPin
 	virtual bool validateInputOutputPins() { return validateInputPins() && validateOutputPins(); } // invoked during Module::init before anything else
-				
+
 	size_t getNumberOfOutputPins() { return mOutputPinIdFrameFactoryMap.size(); }
 	size_t getNumberOfInputPins() { return mInputPinIdMetadataMap.size(); }
 	framemetadata_sp getFirstInputMetadata();
 	framemetadata_sp getFirstOutputMetadata();
-	metadata_by_pin& getInputMetadata() { return mInputPinIdMetadataMap; }
-	framefactory_by_pin& getOutputFrameFactory() { return mOutputPinIdFrameFactoryMap; }
+	metadata_by_pin &getInputMetadata() { return mInputPinIdMetadataMap; }
+	framefactory_by_pin &getOutputFrameFactory() { return mOutputPinIdFrameFactoryMap; }
 	framemetadata_sp getInputMetadataByType(int type);
 	int getNumberOfInputsByType(int type);
 	int getNumberOfOutputsByType(int type);
 	framemetadata_sp getOutputMetadataByType(int type);
-	bool isMetadataEmpty(framemetadata_sp& metadata);
-	bool isFrameEmpty(frame_sp& frame);
+	bool isMetadataEmpty(framemetadata_sp &metadata);
+	bool isFrameEmpty(frame_sp &frame);
 	string getInputPinIdByType(int type);
-	string getOutputPinIdByType(int type);		
-	
-	bool setNext(boost::shared_ptr<Module> next, bool open, bool isFeedback); // take all the output pins			
-	bool setNext(boost::shared_ptr<Module> next, vector<string>& pinIdArr, bool open, bool isFeedback); 
-	void addInputPin(framemetadata_sp& metadata, string& pinId, bool isFeedback); 
-	virtual void addInputPin(framemetadata_sp& metadata, string& pinId); // throws exception if validation fails	
+	string getOutputPinIdByType(int type);
+
+	bool setNext(boost::shared_ptr<Module> next, bool open, bool isFeedback); // take all the output pins
+	bool setNext(boost::shared_ptr<Module> next, vector<string> &pinIdArr, bool open, bool isFeedback);
+	void addInputPin(framemetadata_sp &metadata, string &pinId, bool isFeedback);
+	virtual void addInputPin(framemetadata_sp &metadata, string &pinId); // throws exception if validation fails
 	boost::shared_ptr<FrameContainerQueue> getQue() { return mQue; }
-	
+
 	bool getPlayState() { return mPlay; }
 
 	// only for unit test
-	Connections getConnections() { return mConnections; } 	
-	
+	Connections getConnections() { return mConnections; }
+
 	//following is useful for testing to know whats in queue
 	frame_container try_pop();
 	frame_container pop();
@@ -282,29 +257,30 @@ protected:
 	bool processSourceQue();
 	bool handlePausePlay(bool play);
 	virtual void notifyPlay(bool play) {}
-private:	
-	frame_sp makeFrame(size_t size, framefactory_sp& framefactory);
-	bool push(frame_container frameContainer); //exchanges the buffer 
+
+private:
+	frame_sp makeFrame(size_t size, framefactory_sp &framefactory);
+	bool push(frame_container frameContainer);	   //exchanges the buffer
 	bool try_push(frame_container frameContainer); //tries to exchange the buffer
-	
-	bool addEoPFrame(frame_container& frames);
+
+	bool addEoPFrame(frame_container &frames);
 	bool handleStop();
 
-	template<class T>
-	void serialize(T& props, frame_sp& frame)
+	template <class T>
+	void serialize(T &props, frame_sp &frame)
 	{
-		boost::iostreams::basic_array_sink<char> device_sink((char*)frame->data(), frame->size());
-		boost::iostreams::stream<boost::iostreams::basic_array_sink<char> > s_sink(device_sink);
+		boost::iostreams::basic_array_sink<char> device_sink((char *)frame->data(), frame->size());
+		boost::iostreams::stream<boost::iostreams::basic_array_sink<char>> s_sink(device_sink);
 
 		boost::archive::binary_oarchive oa(s_sink);
 		oa << props;
 	}
 
-	template<class T>
-	void deSerialize(T& props, frame_sp& frame)
+	template <class T>
+	void deSerialize(T &props, frame_sp &frame)
 	{
-		boost::iostreams::basic_array_source<char> device((char*)frame->data(), frame->size());
-		boost::iostreams::stream<boost::iostreams::basic_array_source<char> > s(device);
+		boost::iostreams::basic_array_source<char> device((char *)frame->data(), frame->size());
+		boost::iostreams::stream<boost::iostreams::basic_array_source<char>> s(device);
 		boost::archive::binary_iarchive ia(s);
 
 		ia >> props;
@@ -313,8 +289,8 @@ private:
 	bool shouldForceStep();
 	bool shouldSkip();
 
-	bool isFeedbackEnabled(std::string& moduleId); // get pins and call
-	
+	bool isFeedbackEnabled(std::string &moduleId); // get pins and call
+
 	bool mPlay;
 	uint32_t mForceStepCount;
 	int mSkipIndex;
@@ -329,11 +305,11 @@ private:
 	boost::shared_ptr<FrameFactory> mpFrameFactory;
 	boost::shared_ptr<FrameFactory> mpCommandFactory;
 	boost::shared_ptr<PaceMaker> pacer;
-	
+
 	Connections mConnections; // For each module, all the required pins
 	map<string, boost::shared_ptr<Module>> mModules;
 	map<string, bool> mRelay;
-		
+
 	std::map<std::string, bool> mInputPinsDirection;
 	metadata_by_pin mInputPinIdMetadataMap;
 	framefactory_by_pin mOutputPinIdFrameFactoryMap;

--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -25,15 +25,37 @@ class PaceMaker;
 class ModuleProps
 {
 public:
-	ModuleProps(int _fps = 60, size_t _qlen = 20, bool _logHealth = false, int _logHealthFrequency = 1000, QuePushStrategy::QuePushStrategyType _quePushStrategyType = QuePushStrategy::BLOCKING, size_t _maxConcurrentFrames = 0, FIndexStrategy::FIndexStrategyType _fIndexStrategyType = FIndexStrategy::FIndexStrategyType::AUTO_INCREMENT)
+	struct ModulePropsStruct
 	{
-		fps = _fps;
-		qlen = _qlen;
-		logHealth = _logHealth;
-		logHealthFrequency = _logHealthFrequency;
-		quePushStrategyType = _quePushStrategyType;
-		maxConcurrentFrames = _maxConcurrentFrames;
-		fIndexStrategyType = _fIndexStrategyType;
+		int fps = 60;
+		size_t qlen = 20;
+		bool logHealth = false;
+		int logHealthFrequency = 1000;
+		QuePushStrategy::QuePushStrategyType quePushStrategyType = QuePushStrategy::BLOCKING;
+		size_t maxConcurrentFrames = 0;
+		FIndexStrategy::FIndexStrategyType fIndexStrategyType = FIndexStrategy::FIndexStrategyType::AUTO_INCREMENT;
+	};
+
+	ModuleProps()
+	{
+		ModulePropsStruct modulePropsStruct;
+		initProps(modulePropsStruct);
+	}
+
+	ModuleProps(ModulePropsStruct modulePropsStruct)
+	{
+		initProps(modulePropsStruct);
+	}
+
+	bool initProps(ModulePropsStruct modulePropsStruct)
+	{
+		fps = modulePropsStruct.fps;
+		qlen = modulePropsStruct.qlen;
+		logHealth = modulePropsStruct.logHealth;
+		logHealthFrequency = modulePropsStruct.logHealthFrequency;
+		quePushStrategyType = modulePropsStruct.quePushStrategyType;
+		maxConcurrentFrames = modulePropsStruct.maxConcurrentFrames;
+		fIndexStrategyType = modulePropsStruct.fIndexStrategyType;
 	}
 
 	size_t getQLen()

--- a/base/include/Module.h
+++ b/base/include/Module.h
@@ -25,7 +25,16 @@ class PaceMaker;
 class ModuleProps
 {
 public:
-	ModuleProps(int fps = 60,size_t qlen = 20,bool logHealth = false,int logHealthFrequency = 1000,QuePushStrategy::QuePushStrategyType quePushStrategyType = QuePushStrategy::BLOCKING,size_t maxConcurrentFrames = 0,FIndexStrategy::FIndexStrategyType fIndexStrategyType = FIndexStrategy::FIndexStrategyType::AUTO_INCREMENT){}
+	ModuleProps(int _fps = 60, size_t _qlen = 20, bool _logHealth = false, int _logHealthFrequency = 1000, QuePushStrategy::QuePushStrategyType _quePushStrategyType = QuePushStrategy::BLOCKING, size_t _maxConcurrentFrames = 0, FIndexStrategy::FIndexStrategyType _fIndexStrategyType = FIndexStrategy::FIndexStrategyType::AUTO_INCREMENT)
+	{
+		fps = _fps;
+		qlen = _qlen;
+		logHealth = _logHealth;
+		logHealthFrequency = _logHealthFrequency;
+		quePushStrategyType = _quePushStrategyType;
+		maxConcurrentFrames = _maxConcurrentFrames;
+		fIndexStrategyType = _fIndexStrategyType;
+	}
 
 	size_t getQLen()
 	{

--- a/base/test/module_tests.cpp
+++ b/base/test/module_tests.cpp
@@ -542,7 +542,7 @@ BOOST_AUTO_TEST_CASE(module_frame_container_utils)
 
 BOOST_AUTO_TEST_CASE(module_props)
 {
-	auto module = boost::shared_ptr<TestModule>(new TestModule(Module::SOURCE, "hola", ModuleProps(50, 40, true)));
+	auto module = boost::shared_ptr<TestModule>(new TestModule(Module::SOURCE, "hola", ModuleProps({.fps = 50,.qlen = 40,.logHealth = true})));
 	auto props = module->getProps();
 	BOOST_TEST(props.fps == 50);
 	BOOST_TEST(props.getQLen() == 40);


### PR DESCRIPTION
There were 3 factory constructor for module props which can be replaced with default values in single constructor